### PR TITLE
using native crypto sha-256 when available

### DIFF
--- a/client/js/s3/request-signer.js
+++ b/client/js/s3/request-signer.js
@@ -164,8 +164,25 @@ qq.s3.RequestSigner = function(o) {
                                 promise.failure(e.target.error);
                             }
                             else {
-                                var wordArray = qq.CryptoJS.lib.WordArray.create(e.target.result);
-                                promise.success(qq.CryptoJS.SHA256(wordArray).toString());
+
+                                // if available use faster native code, from https://github.com/FineUploader/fine-uploader/issues/1595
+                                    
+                                if (typeof crypto == 'undefined') {
+
+                                    // IE, original code
+                                    var wordArray = qq.CryptoJS.lib.WordArray.create(e.target.result);
+                                    promise.success(qq.CryptoJS.SHA256(wordArray).toString());
+                                } else if (typeof crypto.webkitSubtle !== 'undefined') {
+                                    // safari
+                                    crypto.webkitSubtle.digest("SHA-256", e.target.result).then(function(digest) {
+                                        promise.success(qq.CryptoJS.lib.WordArray.create(digest).toString());
+                                    });
+                                } else {
+
+                                    crypto.subtle.digest("SHA-256", e.target.result).then(function(digest) {
+                                        promise.success(qq.CryptoJS.lib.WordArray.create(digest).toString());
+                                    });
+                                }
                             }
                         }
                     };


### PR DESCRIPTION
## Brief description of the changes
Using the faster browser native SHA-256 crypto when available for s3 uploads
From https://github.com/FineUploader/fine-uploader/issues/1595